### PR TITLE
Add simple classic-style calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# first-proyect
+# Calculadora
+
+Este proyecto contiene una calculadora con un entorno visual clásico basada en HTML, CSS y JavaScript.
+
+Para probarla abre `index.html` en tu navegador.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Calculadora Clásica</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="calculator">
+        <input type="text" class="display" id="display" readonly>
+        <div class="buttons">
+            <button>7</button>
+            <button>8</button>
+            <button>9</button>
+            <button>/</button>
+            <button>4</button>
+            <button>5</button>
+            <button>6</button>
+            <button>*</button>
+            <button>1</button>
+            <button>2</button>
+            <button>3</button>
+            <button>-</button>
+            <button>0</button>
+            <button>.</button>
+            <button id="clear">C</button>
+            <button>+</button>
+            <button class="equals" id="equals">=</button>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,19 @@
+const display = document.getElementById('display');
+const buttons = document.querySelectorAll('.buttons button');
+
+buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+        const value = btn.textContent;
+        if (value === 'C') {
+            display.value = '';
+        } else if (value === '=') {
+            try {
+                display.value = eval(display.value);
+            } catch {
+                display.value = 'Error';
+            }
+        } else {
+            display.value += value;
+        }
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,45 @@
+body {
+    background-color: #c0c0c0;
+    font-family: Arial, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.calculator {
+    background-color: #f0f0f0;
+    border: 2px solid #808080;
+    padding: 10px;
+    box-shadow: 2px 2px 0 #fff inset, -2px -2px 0 #808080 inset;
+}
+
+.display {
+    width: 100%;
+    margin-bottom: 10px;
+    padding: 5px;
+    font-size: 1.2em;
+    text-align: right;
+    border: 2px solid #808080;
+    box-shadow: inset 2px 2px 0 #fff, inset -2px -2px 0 #808080;
+}
+
+.buttons {
+    display: grid;
+    grid-template-columns: repeat(4, 50px);
+    grid-gap: 5px;
+}
+
+button {
+    padding: 10px;
+    font-size: 1em;
+    background-color: #e0e0e0;
+    border: 2px solid #808080;
+    box-shadow: 2px 2px 0 #fff inset, -2px -2px 0 #808080 inset;
+    cursor: pointer;
+}
+
+button.equals {
+    grid-column: span 4;
+    background-color: #d0d0d0;
+}


### PR DESCRIPTION
## Summary
- add simple web-based calculator with classic look
- provide JavaScript logic for operations
- document how to use the calculator

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68412488ad94832c860a8d0f506731ea